### PR TITLE
add support for 'mul' labels from Wikidata

### DIFF
--- a/src/lib/addLabel.ts
+++ b/src/lib/addLabel.ts
@@ -7,7 +7,7 @@ export default function addLabel(entity: Entity, languageCode: LangCode) {
   const { labels } = entity;
   if (!labels) return;
 
-  let labelObject = labels[languageCode];
+  let labelObject = labels.mul || labels[languageCode];
   if (!labelObject)
     for (const defaultLangCode of DEFAULT_LANGS_CODES) {
       const defaultLangLabel = labels[defaultLangCode];

--- a/src/treeHelpers/getEntities.ts
+++ b/src/treeHelpers/getEntities.ts
@@ -53,7 +53,7 @@ export default async function getEntities(
     return entities;
   }
 
-  const languages = DEFAULT_LANGS_CODES;
+  const languages = ["mul"].concat(DEFAULT_LANGS_CODES);
 
   //avoid duplicate language, but it won't break anyway
   if (!languages.includes(languageCode)) languages.push(languageCode);

--- a/src/wikibase/getWikibaseEntitiesLabel.ts
+++ b/src/wikibase/getWikibaseEntitiesLabel.ts
@@ -15,7 +15,7 @@ export default async function getWikibaseEntitiesLabel(
 
   const allentities = await getWikibaseEntities({
     ids,
-    languages: [languageCode].concat(DEFAULT_LANGS_CODES),
+    languages: ["mul", languageCode].concat(DEFAULT_LANGS_CODES),
     props: ["labels"],
     dataSource,
   });


### PR DESCRIPTION
Adds support for Wikidata `mul` labels as the primary label source.

## Changes

- Fetches `mul` labels alongside the existing label languages.
- Prefers `labels.mul` when available.
- Falls back to the selected language and then the existing default language order, preserving the current behavior when no `mul` label exists.
